### PR TITLE
Add branch alias to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,11 @@
     "issues": "https://github.com/TehTux/jh_captcha/issues",
     "docs": "https://docs.typo3.org/typo3cms/extensions/jh_captcha/"
   },
+  "extra": {
+    "branch-alias": {
+      "dev-develop": "2.0.x-dev"
+    }
+  },
   "require": {
     "typo3/cms-core": ">=7.6.0,<9.0"
   },


### PR DESCRIPTION
To be able to require ^2.0.0 already now, the composer.json should contain a branch alias.